### PR TITLE
fix: contact sales link

### DIFF
--- a/app/components/application/AppPlansOverview/AppPlansOverview.tsx
+++ b/app/components/application/AppPlansOverview/AppPlansOverview.tsx
@@ -73,7 +73,7 @@ export default function AppPlansOverview({ planType }: AppPlansOverviewProps) {
             <Text mt={8} weight="lighter">
               {AppPlansOverview.planDetails.enterpriseSolutions.description}{" "}
               <Text color="var(--color-primary-main)" component="span">
-                <Link to="/dashboard/contact-sales">
+                <Link to="/contact-sales">
                   {AppPlansOverview.planDetails.enterpriseSolutions.contactUS}
                 </Link>
               </Text>

--- a/app/locales/en.tsx
+++ b/app/locales/en.tsx
@@ -444,7 +444,7 @@ const schema = {
           FAQs{" "}
         </Link>
         for more information and
-        <Link className="pokt-link" to="/dashboard/contact-sales">
+        <Link className="pokt-link" to="/contact-sales">
           {" "}
           contact us{" "}
         </Link>

--- a/app/locales/fr.tsx
+++ b/app/locales/fr.tsx
@@ -433,7 +433,7 @@ const schema = {
           FAQs{" "}
         </Link>
         for more information and
-        <Link className="pokt-link" to="/dashboard/contact-sales">
+        <Link className="pokt-link" to="/contact-sales">
           {" "}
           contact us{" "}
         </Link>


### PR DESCRIPTION
# Overview

Fix links going to /dashboard/contact-sales instead of /contact-sales