### PR TITLE
force redirect to auth0 instead of keeping session

### DIFF
--- a/app/context/TranslateContext.tsx
+++ b/app/context/TranslateContext.tsx
@@ -218,6 +218,15 @@ interface TranslationData {
         appsLimit: string
         chainAccess: string
       }
+      [PayPlanType.Enterprise]: {
+        title: string
+        description: string
+        description2: string
+        pricing: string
+        relayLimit: string
+        appsLimit: string
+        chainAccess: string
+      }
       enterpriseSolutions: {
         description: string
         contactUS: string

--- a/app/locales/en.tsx
+++ b/app/locales/en.tsx
@@ -306,6 +306,15 @@ const schema = {
         appsLimit: "Up to 2 Applicaitions",
         chainAccess: "No limit",
       },
+      [PayPlanType.Enterprise]: {
+        title: "Enterprise",
+        description: "Custom plans for large scale apps.",
+        description2: "",
+        pricing: "Contact Us",
+        relayLimit: "",
+        appsLimit: "",
+        chainAccess: "",
+      },
       enterpriseSolutions: {
         description: "Custom plans for large scale apps.",
         contactUS: "Contact Us",

--- a/app/locales/fr.tsx
+++ b/app/locales/fr.tsx
@@ -295,6 +295,15 @@ const schema = {
         appsLimit: "Up to 2 Applicaitions -fr",
         chainAccess: "No limit -fr",
       },
+      [PayPlanType.Enterprise]: {
+        title: "Enterprise -fr",
+        description: "Custom plans for large scale apps. -fr",
+        description2: "",
+        pricing: "Contact Us -fr",
+        relayLimit: "",
+        appsLimit: "",
+        chainAccess: "",
+      },
       enterpriseSolutions: {
         description: "Custom plans for large scale apps. -fr",
         contactUS: "Contact Us -fr",

--- a/app/routes/api/auth/auth0.tsx
+++ b/app/routes/api/auth/auth0.tsx
@@ -31,7 +31,10 @@ export let action: ActionFunction = async ({ request }) => {
     })
   }
 
-  return authenticator.authenticate("auth0", request, {
+  const url = new URL(request.url)
+  url.searchParams.append("prompt", "login")
+  const loginRequest = new Request(url.toString(), request)
+  return authenticator.authenticate("auth0", loginRequest, {
     successRedirect: "/dashboard",
     failureRedirect: "/",
   })


### PR DESCRIPTION
# Overview

> Auth0 was keeping a user session even after logging out. We have had enough people complain about this.
>  Change: force redirect to auth0 instead of keeping session
> users will now be forced to fully log back in
