### PR TITLE
feat: add hidden account addresses

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm run test:unit:changed
+pnpm run test:unit:run

--- a/app/components/application/AppAddressCard/AppAddressCard.test.tsx
+++ b/app/components/application/AppAddressCard/AppAddressCard.test.tsx
@@ -28,7 +28,10 @@ describe("<AppAddressCard />", () => {
     expect(screen.getByText(numberOfApps)).toBeInTheDocument()
   })
   it("hides extra apps when there are more than 3 and allows users to expand", async () => {
-    const extraApps = apps?.concat([{ appId: "345", address: "", publicKey: "" }, { appId: "456", address: "", publicKey: "" } ])
+    const extraApps = apps?.concat([
+      { appId: "345", address: "", publicKey: "" },
+      { appId: "456", address: "", publicKey: "" },
+    ])
     render(<AppAddressCard apps={extraApps} />)
     const numberOfApps = "4"
     expect(screen.getByText(numberOfApps)).toBeInTheDocument()

--- a/app/components/application/AppAddressCard/AppAddressCard.test.tsx
+++ b/app/components/application/AppAddressCard/AppAddressCard.test.tsx
@@ -1,6 +1,6 @@
 import { expect } from "vitest"
 import AppAddressCard from "./AppAddressCard"
-import { fireEvent, render, screen } from "test/helpers"
+import { fireEvent, render, screen, userEvent, waitFor } from "test/helpers"
 import schema from "~/locales/en"
 import { ProcessedEndpoint } from "~/models/portal/sdk"
 
@@ -28,9 +28,8 @@ describe("<AppAddressCard />", () => {
     expect(screen.getByText(numberOfApps)).toBeInTheDocument()
   })
   it("hides extra apps when there are more than 3 and allows users to expand", async () => {
-    apps?.push({ appId: "345", address: "", publicKey: "" })
-    apps?.push({ appId: "456", address: "", publicKey: "" })
-    render(<AppAddressCard apps={apps} />)
+    const extraApps = apps?.concat([{ appId: "345", address: "", publicKey: "" }, { appId: "456", address: "", publicKey: "" } ])
+    render(<AppAddressCard apps={extraApps} />)
     const numberOfApps = "4"
     expect(screen.getByText(numberOfApps)).toBeInTheDocument()
     expect(
@@ -47,5 +46,41 @@ describe("<AppAddressCard />", () => {
     render(<AppAddressCard apps={[]} />)
     const errorText = schema.appAddressCard.error
     expect(screen.getByText(errorText)).toBeInTheDocument()
+  })
+  it("displays show, hide and copy buttons properly", () => {
+    render(<AppAddressCard apps={apps} />)
+    const showText = /Click to show value/i
+    const hideText = /Click to hide value/i
+    const copyText = /Click to copy/i
+    expect(screen.getAllByLabelText(showText)).toHaveLength(2)
+    expect(screen.queryByLabelText(hideText)).not.toBeInTheDocument()
+    expect(screen.getAllByLabelText(copyText)).toHaveLength(2)
+  })
+  it("shows and hides from revealIcon", async () => {
+    render(<AppAddressCard apps={apps} />)
+    const user = userEvent.setup()
+    const showText = /Click to show value/i
+    const hideText = /Click to hide value/i
+    expect(screen.getAllByLabelText(showText)).toHaveLength(2)
+    expect(screen.queryByLabelText(hideText)).not.toBeInTheDocument()
+
+    // click one of the show buttons
+    user.click(screen.getAllByLabelText(showText)[0])
+    await waitFor(() => {
+      expect(screen.getByLabelText(hideText)).toBeInTheDocument()
+    })
+
+    // click the remaining show button
+    user.click(screen.getAllByLabelText(showText)[0])
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(hideText)).toHaveLength(2)
+    })
+
+    // click both hide buttons
+    user.click(screen.getAllByLabelText(hideText)[0])
+    user.click(screen.getAllByLabelText(hideText)[1])
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(showText)).toHaveLength(2)
+    })
   })
 })

--- a/app/components/application/AppAddressCard/AppAddressCard.tsx
+++ b/app/components/application/AppAddressCard/AppAddressCard.tsx
@@ -54,11 +54,7 @@ export default function AppAddressCard({ apps }: AppAddressCardProps) {
                 key={appId}
                 copy
                 readOnly
-                value={appId}
                 revealed={hiddenIds.includes(appId)}
-                // Check either if the appId is or isn't included in the hiddenIds array,
-                // if it is, remove it
-                // if it's not, add it
                 setRevealed={() =>
                   setHiddenIds(
                     hiddenIds.includes(appId)
@@ -66,7 +62,11 @@ export default function AppAddressCard({ apps }: AppAddressCardProps) {
                       : [...hiddenIds, appId],
                   )
                 }
+                // Check either if the appId is or isn't included in the hiddenIds array,
+                // if it is, remove it
+                // if it's not, add it
                 type={hiddenIds.includes(appId) ? "password" : "text"}
+                value={appId}
               />
             ) : null,
           )
@@ -82,11 +82,7 @@ export default function AppAddressCard({ apps }: AppAddressCardProps) {
                     key={appId}
                     copy
                     readOnly
-                    value={appId}
                     revealed={hiddenIds.includes(appId)}
-                    // Check either if the appId is or isn't included in the hiddenIds array,
-                    // if it is, remove it
-                    // if it's not, add it
                     setRevealed={() =>
                       setHiddenIds(
                         hiddenIds.includes(appId)
@@ -94,7 +90,11 @@ export default function AppAddressCard({ apps }: AppAddressCardProps) {
                           : [...hiddenIds, appId],
                       )
                     }
+                    // Check either if the appId is or isn't included in the hiddenIds array,
+                    // if it is, remove it
+                    // if it's not, add it
                     type={hiddenIds.includes(appId) ? "password" : "text"}
+                    value={appId}
                   />
                 ) : null,
               )}

--- a/app/components/application/AppAddressCard/AppAddressCard.tsx
+++ b/app/components/application/AppAddressCard/AppAddressCard.tsx
@@ -28,6 +28,10 @@ export default function AppAddressCard({ apps }: AppAddressCardProps) {
     t: { appAddressCard },
   } = useTranslate()
   const [showAllApps, setShowAllApps] = useState(false)
+  const [hiddenIds, setHiddenIds] = useState<string[]>(() => {
+    // all ids are hidden by default
+    return apps?.length ? apps?.map(({ appId }) => appId) : []
+  })
   const visibleApps = apps ? apps.slice(0, 3) : apps
   const hiddenApps = apps ? apps.slice(3) : undefined
 
@@ -44,8 +48,27 @@ export default function AppAddressCard({ apps }: AppAddressCardProps) {
           {apps && apps.length > 0 && <p>{apps.length}</p>}
         </div>
         {visibleApps && visibleApps.length > 0 ? (
-          visibleApps.map((item) =>
-            item ? <TextInput key={item.appId} copy readOnly value={item.appId} /> : null,
+          visibleApps.map(({ appId }) =>
+            appId ? (
+              <TextInput
+                key={appId}
+                copy
+                readOnly
+                value={appId}
+                revealed={hiddenIds.includes(appId)}
+                // Check either if the appId is or isn't included in the hiddenIds array,
+                // if it is, remove it
+                // if it's not, add it
+                setRevealed={() =>
+                  setHiddenIds(
+                    hiddenIds.includes(appId)
+                      ? hiddenIds.filter((app) => app !== appId)
+                      : [...hiddenIds, appId],
+                  )
+                }
+                type={hiddenIds.includes(appId) ? "password" : "text"}
+              />
+            ) : null,
           )
         ) : (
           <p>{appAddressCard.error}</p>
@@ -53,9 +76,26 @@ export default function AppAddressCard({ apps }: AppAddressCardProps) {
         {hiddenApps && hiddenApps.length > 0 && (
           <>
             <Collapse in={showAllApps}>
-              {hiddenApps.map((item) =>
-                item ? (
-                  <TextInput key={item.appId} copy readOnly value={item.appId} />
+              {hiddenApps.map(({ appId }) =>
+                appId ? (
+                  <TextInput
+                    key={appId}
+                    copy
+                    readOnly
+                    value={appId}
+                    revealed={hiddenIds.includes(appId)}
+                    // Check either if the appId is or isn't included in the hiddenIds array,
+                    // if it is, remove it
+                    // if it's not, add it
+                    setRevealed={() =>
+                      setHiddenIds(
+                        hiddenIds.includes(appId)
+                          ? hiddenIds.filter((app) => app !== appId)
+                          : [...hiddenIds, appId],
+                      )
+                    }
+                    type={hiddenIds.includes(appId) ? "password" : "text"}
+                  />
                 ) : null,
               )}
             </Collapse>

--- a/app/components/application/AppKeysCard/AppKeysCard.tsx
+++ b/app/components/application/AppKeysCard/AppKeysCard.tsx
@@ -29,7 +29,7 @@ export default function AppKeysCard({ id, secret, publicKey }: AppKeysCardProps)
             readOnly
             label="Secret Key"
             revealed={secretHidden}
-            setRevealed={setSecretHidden}
+            setRevealed={() => setSecretHidden(!secretHidden)}
             type={secretHidden ? "password" : "text"}
             value={secret}
           />
@@ -41,7 +41,7 @@ export default function AppKeysCard({ id, secret, publicKey }: AppKeysCardProps)
             readOnly
             label="Public Key"
             revealed={publicKeyHidden}
-            setRevealed={setPublicKeyHidden}
+            setRevealed={() => setPublicKeyHidden(!publicKeyHidden)}
             type={publicKeyHidden ? "password" : "text"}
             value={publicKey}
           />

--- a/app/components/shared/RevealIcon/RevealIcon.tsx
+++ b/app/components/shared/RevealIcon/RevealIcon.tsx
@@ -1,4 +1,5 @@
 import { IconEyeOn, IconEyeOff } from "@pokt-foundation/pocket-blocks"
+import { Dispatch, SetStateAction } from "react"
 import styles from "./styles.css"
 
 /* c8 ignore start */
@@ -9,7 +10,7 @@ export const links = () => {
 
 type RevealIconProps = {
   revealed: boolean
-  setRevealed: Function
+  setRevealed: () => void
 }
 
 export default function RevealIcon({ revealed, setRevealed }: RevealIconProps) {
@@ -18,7 +19,7 @@ export default function RevealIcon({ revealed, setRevealed }: RevealIconProps) {
       aria-label={`Click to ${revealed ? "show" : "hide"} value`}
       className="pokt-reveal"
       tabIndex={0}
-      onClick={() => setRevealed(!revealed)}
+      onClick={setRevealed}
     >
       {revealed ? (
         <IconEyeOn fill="var(--color-secondary-main)" />

--- a/app/components/shared/RevealIcon/RevealIcon.tsx
+++ b/app/components/shared/RevealIcon/RevealIcon.tsx
@@ -1,5 +1,4 @@
 import { IconEyeOn, IconEyeOff } from "@pokt-foundation/pocket-blocks"
-import { Dispatch, SetStateAction } from "react"
 import styles from "./styles.css"
 
 /* c8 ignore start */

--- a/app/components/shared/TextInput/TextInput.tsx
+++ b/app/components/shared/TextInput/TextInput.tsx
@@ -23,7 +23,7 @@ export type InputProps = TextInputProps & {
   hasDelete?: boolean
   iconPadding?: boolean
   handleRemove?: () => void
-  setRevealed?: Function
+  setRevealed?: () => void
 }
 
 export default function TextInput({

--- a/app/locales/en.tsx
+++ b/app/locales/en.tsx
@@ -15,7 +15,7 @@ const schema = {
   search: {
     label: "Search",
     placeholder: "Search by Transaction Hash, Block # and Address",
-    searchBy: "Search by"
+    searchBy: "Search by",
   },
   terms: {
     address: "address",

--- a/app/locales/fr.tsx
+++ b/app/locales/fr.tsx
@@ -15,7 +15,7 @@ const schema = {
   search: {
     label: "Search -fr",
     placeholder: "Search by Transaction Hash, Block # and Address -fr",
-    searchBy: "Search by -fr"
+    searchBy: "Search by -fr",
   },
   terms: {
     address: "address -fr",


### PR DESCRIPTION
# Overview
Enable the hide/show function on the user App Address section. The default is hidden and the user can click to show the address of each item on a list of addresses.

Note: Changed pre-commit test command. 

# Type of change

- [ ] Bug fix (non-breaking change; fixes an issue).
- [x] New feature (non-breaking change; adds functionality).
- [ ] Breaking change (fix or feature that breaks existing functionality).
- [ ] This change requires a documentation update.
- [ ] Operational change.
- [ ] Test Coverage.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

# Dependencies

# Test Configuration

- Hardware: **Macbook Air M1**
- OS: **macOS 12.4**
- Node version: **16.18.0**
- PNPM version: **7.22.0**


# Evidence

![Screen Shot 2023-01-23 at 20 03 37](https://user-images.githubusercontent.com/90636779/214597195-120eb2d3-1a10-43bc-a58f-2a99b0ef07de.png)
![Screen Shot 2023-01-23 at 20 03 49](https://user-images.githubusercontent.com/90636779/214597203-70f7e267-e89f-489e-82fd-bf4795f59606.png)
