### PR TITLE
fix: textinput styling

### DIFF
--- a/app/components/shared/TextInput/TextInput.tsx
+++ b/app/components/shared/TextInput/TextInput.tsx
@@ -35,13 +35,17 @@ export default function TextInput({
         variant={props.variant ?? "filled"}
         {...props}
         sx={{
-          backgroundColor: theme.colors.navy ? theme.colors.navy[6] : "blue",
           flexGrow: 1,
           marginBottom: 0,
 
           ".mantine-TextInput-input": {
             padding: props.rightSection ? ".5em 5em .5em .5em" : ".5em",
             fontSize: "0.75em",
+            backgroundColor: theme.colors.navy ? theme.colors.navy[6] : "blue",
+          },
+          ".mantine-TextInput-label": {
+            fontWeight: 600,
+            fontSize: "1em",
           },
         }}
       />

--- a/app/views/dashboard/apps/index/appsView.tsx
+++ b/app/views/dashboard/apps/index/appsView.tsx
@@ -250,7 +250,9 @@ export const AppsView = ({
               <Tabs.Tab value="applications">My Applications</Tabs.Tab>
               {notOwnerEndpoints &&
                 notOwnerEndpoints.length > 0 &&
-                userDataByEndpoint.length > 0 && <Tabs.Tab value="teams">My Teams</Tabs.Tab>}
+                userDataByEndpoint.length > 0 && (
+                  <Tabs.Tab value="teams">My Teams</Tabs.Tab>
+                )}
             </Tabs.List>
 
             <Tabs.Panel value="applications">


### PR DESCRIPTION
# Overview
- Fixes text input component styling
- Moves input background from the entire component to only wrap the input
- Adds weight to the label and increases size to 1em (16px)

# Evidence

![image](https://user-images.githubusercontent.com/26576400/236268908-f86237a7-c6d3-4390-8a40-14a9d1f1d841.png)