### PR TITLE
fix: plan not updating if the user has a subscription

### DIFF
--- a/app/views/dashboard/apps/appId/layout/appIdLayoutView.tsx
+++ b/app/views/dashboard/apps/appId/layout/appIdLayoutView.tsx
@@ -189,6 +189,27 @@ export default function AppIdLayoutView({
     }
   }, [endpoint, subscription, updatePlanFetcher])
 
+  useEffect(() => {
+    // update plan type to paid if plan is free and there is a subscription
+    if (
+      endpoint?.appLimits.planType === PayPlanType.FreetierV0 &&
+      subscription &&
+      updatePlanFetcher.state !== "submitting" &&
+      updatePlanFetcher.state !== "loading"
+    ) {
+      updatePlanFetcher.submit(
+        {
+          id: endpoint.id,
+          type: PayPlanType.PayAsYouGoV0,
+        },
+        {
+          action: "/api/updatePlan",
+          method: "post",
+        },
+      )
+    }
+  }, [endpoint, subscription, updatePlanFetcher])
+
   const role = endpoint?.users.find((u) => u.email === user._json?.email)?.roleName
   const isMember = role === RoleName.Member
   const isAdmin = role === RoleName.Admin


### PR DESCRIPTION
# Overview

After making a payment the plan won't upgrade from Free tier to Paid tier. 

This PR fixes the problem by adding a useEffect logic to check every time the user goes to the apps page to upgrade from the Free tier. 

# Type of change

- [x] Bug fix (non-breaking change; fixes an issue).
- [ ] New feature (non-breaking change; adds functionality).
- [ ] Breaking change (fix or feature that breaks existing functionality).
- [ ] This change requires a documentation update.
- [ ] Operational change.
- [ ] Test Coverage.
