### PR TITLE
feat: use splat route to get nested routing inside docs

### DIFF
--- a/app/routes/_landing.($lang).docs.$/route.tsx
+++ b/app/routes/_landing.($lang).docs.$/route.tsx
@@ -1,0 +1,69 @@
+import { LoaderFunction, json } from "@remix-run/node"
+import { useLoaderData } from "@remix-run/react"
+import invariant from "tiny-invariant"
+import NotFound404 from "~/components/NotFound404"
+import Remark from "~/components/Remark"
+import { initCmsClient } from "~/models/cms/cms.server"
+import { documentation } from "~/models/cms/sdk"
+import { getClientEnv } from "~/utils/environment.server"
+
+type LoaderData = {
+  data: documentation[]
+}
+
+export const loader: LoaderFunction = async ({ params }) => {
+  const routelang = params.lang !== undefined ? params.lang : "en-US"
+  const cms = initCmsClient()
+  const showOnlyPublished = getClientEnv().DOCS_STATUS === "published"
+  const splatParams = params["*"] as string
+  invariant(typeof splatParams === "string", "Undefined splat route")
+  const splittedParams = splatParams.split("/")
+  const slug = splittedParams[splittedParams.length - 1]
+
+  try {
+    const doc = await cms.getDocs({
+      filter: {
+        slug: { _eq: slug },
+        ...(showOnlyPublished && { status: { _eq: "published" } }),
+      },
+      sort: ["id"],
+      language: routelang,
+    })
+
+    if (
+      doc.documentation[0].translations &&
+      typeof doc.documentation[0]?.translations[0]?.body !== "string" &&
+      typeof doc.documentation[0].translations[0]?.id !== "string" &&
+      typeof doc.documentation[0].translations[0]?.title !== "string"
+    ) {
+      throw new Error("Page must have markdown body")
+    }
+
+    return json<LoaderData>({
+      data: doc.documentation,
+    })
+  } catch (e) {
+    console.error(`Docs error in ${params.slug}: `, e)
+    throw new Error(`Error: ${e}`)
+  }
+}
+
+export default function Docs() {
+  const { data }: LoaderData = useLoaderData()
+
+  return (
+    <Remark>
+      {data &&
+      data[0] &&
+      data[0].translations &&
+      data[0].translations[0] &&
+      data[0].translations[0].body
+        ? data[0].translations[0].body
+        : ""}
+    </Remark>
+  )
+}
+
+export const ErrorBoundary = () => {
+  return <NotFound404 />
+}

--- a/app/utils/docs.ts
+++ b/app/utils/docs.ts
@@ -1,17 +1,24 @@
 import { LinksGroupProps } from "~/components/LinksGroup/LinksGroup"
 import { documentation } from "~/models/cms/sdk"
 
-export const findChildren = (docId: string, docs: documentation[]): LinksGroupProps[] => {
+export const findChildren = (
+  docId: string,
+  docs: documentation[],
+  parentSlug: string = "",
+): LinksGroupProps[] => {
   return docs
     .filter((doc) => doc.parent?.id === docId)
-    .map((doc) => ({
-      id: doc.id,
-      label: doc.translations?.[0]?.title || "",
-      link: `${doc.parent?.slug}/${doc.slug}` || "",
-      slug: doc.slug || "",
-      links: findChildren(doc.id, docs),
-      hasParent: true,
-    }))
+    .map((doc) => {
+      const slugPath = `${parentSlug}/${doc.slug}`
+      return {
+        id: doc.id,
+        label: doc.translations?.[0]?.title || "",
+        link: slugPath || "",
+        slug: doc.slug || "",
+        links: findChildren(doc.id, docs, slugPath),
+        hasParent: true,
+      }
+    })
 }
 
 export const organizeData = (docs: documentation[]): LinksGroupProps[] => {
@@ -22,7 +29,7 @@ export const organizeData = (docs: documentation[]): LinksGroupProps[] => {
       label: doc.translations?.[0]?.title || "",
       link: doc.slug || "",
       slug: doc.slug || "",
-      links: findChildren(doc.id, docs),
+      links: findChildren(doc.id, docs, doc.slug!),
       hasParent: false,
     }))
 }

--- a/app/utils/docs.ts
+++ b/app/utils/docs.ts
@@ -7,7 +7,7 @@ export const findChildren = (docId: string, docs: documentation[]): LinksGroupPr
     .map((doc) => ({
       id: doc.id,
       label: doc.translations?.[0]?.title || "",
-      link: doc.slug || "",
+      link: `${doc.parent?.slug}/${doc.slug}` || "",
       slug: doc.slug || "",
       links: findChildren(doc.id, docs),
       hasParent: true,


### PR DESCRIPTION
# Overview

- Fixes docs routing. Basically allows docs to have routes like introduction/what-is-the-portal. This is possible because of splat routes.
- Fixes sidebar links