### PR TITLE
Mobile searchbar

### DIFF
--- a/app/hooks/usePagination.ts
+++ b/app/hooks/usePagination.ts
@@ -32,14 +32,20 @@ export const usePagination = ({
     [paginate],
   )
 
-  const totalData = useMemo(() => search && searchTerm
-    ? data.filter((row) => {
-      const columns = Object.values(row).map((column) => typeof column === "object" ? column.value : column)
-      const filter = columns.join().toLowerCase().trim()
-      const exists = filter.includes(searchTerm.toLowerCase().trim())
-      return exists
-    })
-    : data, [data, search, searchTerm])
+  const totalData = useMemo(
+    () =>
+      search && searchTerm
+        ? data.filter((row) => {
+            const columns = Object.values(row).map((column) =>
+              typeof column === "object" ? column.value : column,
+            )
+            const filter = columns.join().toLowerCase().trim()
+            const exists = filter.includes(searchTerm.toLowerCase().trim())
+            return exists
+          })
+        : data,
+    [data, search, searchTerm],
+  )
 
   const totalPages = useMemo(
     () =>
@@ -49,8 +55,10 @@ export const usePagination = ({
     [totalData, perPage, paginate],
   )
 
-  const paginatedData = useMemo(() => paginate ? totalData.slice((page - 1) * perPage, page * perPage) : totalData
-    , [totalData, paginate, page, perPage])
+  const paginatedData = useMemo(
+    () => (paginate ? totalData.slice((page - 1) * perPage, page * perPage) : totalData),
+    [totalData, paginate, page, perPage],
+  )
 
   const handlePageChange = (newPage: number) => {
     setPage(newPage)

--- a/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
+++ b/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
@@ -35,7 +35,7 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
       itemComponent={AutoCompleteSearchItem}
       limit={20}
       nothingFound={nothingFoundText}
-      placeholder="Search"
+      placeholder="Search in Docs"
       rightSection={autocompleteRightSection}
       rightSectionWidth={25}
       size="md"
@@ -44,7 +44,7 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
           paddingRight: 5,
         },
       }}
-      sx={() => ({
+      sx={(theme) => ({
         width: "560px",
         ".mantine-Autocomplete-itemsWrapper": {
           maxHeight: "500px",
@@ -55,6 +55,18 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
         },
         ".mantine-Autocomplete-input": {
           width: "350px",
+          backgroundColor: "transparent",
+          borderColor: theme.colors.gray[4],
+
+          "&::placeholder": {
+            color: theme.colors.gray[4],
+          },
+        },
+        ".mantine-Autocomplete-icon": {
+          color: theme.colors.gray[3],
+        },
+        ".mantine-Autocomplete-dropdown": {
+          backgroundColor: theme.colors.navy[6],
         },
       })}
       value={searchTerm}

--- a/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
+++ b/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
@@ -1,8 +1,10 @@
 import {
   Autocomplete,
   AutocompleteItem,
+  AutocompleteProps,
   IconSearch,
   MediaQuery,
+  Sx,
 } from "@pokt-foundation/pocket-blocks"
 import { useFetcher, useNavigate } from "@remix-run/react"
 import { useState } from "react"
@@ -14,10 +16,15 @@ interface DocumentationSearchProps {
   docsLinks: LinksGroupProps[]
 }
 
-export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => {
+interface PAutocompleteProps
+  extends DocumentationSearchProps,
+    Partial<AutocompleteProps> {
+  sx?: Sx | (Sx | undefined)[] | undefined
+}
+
+function PAutocomplete({ docsLinks, sx, ...props }: PAutocompleteProps) {
   const navigate = useNavigate()
   const fetcher = useFetcher()
-  const [mobileExpanded, setMobileExpanded] = useState(false)
 
   const {
     searchResultsData,
@@ -29,26 +36,47 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
   } = useDocumentationSearch({ fetcher, docsLinks })
 
   return (
+    <Autocomplete
+      {...props}
+      aria-label="Documentation search"
+      data={fetcher.state === "submitting" ? [] : searchResultsData}
+      dropdownComponent="div"
+      filter={(_, item) => Boolean(item.value)}
+      icon={<IconSearch />}
+      itemComponent={AutoCompleteSearchItem}
+      limit={20}
+      nothingFound={nothingFoundText}
+      placeholder="Search in Docs"
+      rightSection={autocompleteRightSection}
+      rightSectionWidth={25}
+      size="md"
+      styles={{
+        rightSection: {
+          paddingRight: 5,
+        },
+      }}
+      sx={sx}
+      value={searchTerm}
+      onChange={(term) => {
+        setSearchResults([])
+        setSearchTerm(term)
+      }}
+      onItemSubmit={(item: AutocompleteItem) => {
+        navigate(item.link)
+        setSearchTerm("")
+      }}
+    />
+  )
+}
+
+export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => {
+  const [mobileExpanded, setMobileExpanded] = useState(false)
+
+  return (
     <>
       <MediaQuery largerThan="md" styles={{ display: "none" }}>
-        <Autocomplete
-          aria-label="Documentation search"
-          data={fetcher.state === "submitting" ? [] : searchResultsData}
-          dropdownComponent="div"
-          filter={(_, item) => Boolean(item.value)}
-          icon={<IconSearch />}
-          itemComponent={AutoCompleteSearchItem}
-          limit={20}
-          nothingFound={nothingFoundText}
-          placeholder="Search in Docs"
-          rightSection={autocompleteRightSection}
-          rightSectionWidth={25}
-          size="md"
-          styles={{
-            rightSection: {
-              paddingRight: 5,
-            },
-          }}
+        <PAutocomplete
+          docsLinks={docsLinks}
           sx={(theme) => ({
             width: "280px",
             ".mantine-Autocomplete-itemsWrapper": {
@@ -75,39 +103,14 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
               backgroundColor: theme.colors.navy[6],
             },
           })}
-          value={searchTerm}
-          onChange={(term) => {
-            setSearchResults([])
-            setSearchTerm(term)
-          }}
           onClick={() => setMobileExpanded(true)}
           onDropdownClose={() => setMobileExpanded(false)}
-          onItemSubmit={(item: AutocompleteItem) => {
-            navigate(item.link)
-            setSearchTerm("")
-          }}
         />
       </MediaQuery>
 
       <MediaQuery smallerThan="md" styles={{ display: "none" }}>
-        <Autocomplete
-          aria-label="Documentation search"
-          data={fetcher.state === "submitting" ? [] : searchResultsData}
-          dropdownComponent="div"
-          filter={(_, item) => Boolean(item.value)}
-          icon={<IconSearch />}
-          itemComponent={AutoCompleteSearchItem}
-          limit={20}
-          nothingFound={nothingFoundText}
-          placeholder="Search in Docs"
-          rightSection={autocompleteRightSection}
-          rightSectionWidth={25}
-          size="md"
-          styles={{
-            rightSection: {
-              paddingRight: 5,
-            },
-          }}
+        <PAutocomplete
+          docsLinks={docsLinks}
           sx={(theme) => ({
             width: "560px",
             ".mantine-Autocomplete-itemsWrapper": {
@@ -133,15 +136,6 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
               backgroundColor: theme.colors.navy[6],
             },
           })}
-          value={searchTerm}
-          onChange={(term) => {
-            setSearchResults([])
-            setSearchTerm(term)
-          }}
-          onItemSubmit={(item: AutocompleteItem) => {
-            navigate(item.link)
-            setSearchTerm("")
-          }}
         />
       </MediaQuery>
     </>

--- a/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
+++ b/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
@@ -2,8 +2,10 @@ import {
   Autocomplete,
   AutocompleteItem,
   IconSearch,
+  MediaQuery,
 } from "@pokt-foundation/pocket-blocks"
 import { useFetcher, useNavigate } from "@remix-run/react"
+import { useState } from "react"
 import { LinksGroupProps } from "~/components/LinksGroup/LinksGroup"
 import AutoCompleteSearchItem from "~/components/SearchAutoCompleteItem"
 import { useDocumentationSearch } from "~/routes/_landing.($lang).docs/hooks"
@@ -15,6 +17,7 @@ interface DocumentationSearchProps {
 export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => {
   const navigate = useNavigate()
   const fetcher = useFetcher()
+  const [mobileExpanded, setMobileExpanded] = useState(false)
 
   const {
     searchResultsData,
@@ -26,59 +29,122 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
   } = useDocumentationSearch({ fetcher, docsLinks })
 
   return (
-    <Autocomplete
-      aria-label="Documentation search"
-      data={fetcher.state === "submitting" ? [] : searchResultsData}
-      dropdownComponent="div"
-      filter={(value, item) => Boolean(item.value)}
-      icon={<IconSearch />}
-      itemComponent={AutoCompleteSearchItem}
-      limit={20}
-      nothingFound={nothingFoundText}
-      placeholder="Search in Docs"
-      rightSection={autocompleteRightSection}
-      rightSectionWidth={25}
-      size="md"
-      styles={{
-        rightSection: {
-          paddingRight: 5,
-        },
-      }}
-      sx={(theme) => ({
-        width: "560px",
-        ".mantine-Autocomplete-itemsWrapper": {
-          maxHeight: "500px",
-        },
-        ".mantine-Autocomplete-wrapper": {
-          display: "flex",
-          justifyContent: "flex-end",
-        },
-        ".mantine-Autocomplete-input": {
-          width: "350px",
-          backgroundColor: "transparent",
-          borderColor: theme.colors.gray[4],
+    <>
+      <MediaQuery largerThan="md" styles={{ display: "none" }}>
+        <Autocomplete
+          aria-label="Documentation search"
+          data={fetcher.state === "submitting" ? [] : searchResultsData}
+          dropdownComponent="div"
+          filter={(_, item) => Boolean(item.value)}
+          icon={<IconSearch />}
+          itemComponent={AutoCompleteSearchItem}
+          limit={20}
+          nothingFound={nothingFoundText}
+          placeholder="Search in Docs"
+          rightSection={autocompleteRightSection}
+          rightSectionWidth={25}
+          size="md"
+          styles={{
+            rightSection: {
+              paddingRight: 5,
+            },
+          }}
+          sx={(theme) => ({
+            width: "280px",
+            ".mantine-Autocomplete-itemsWrapper": {
+              maxHeight: "500px",
+            },
+            ".mantine-Autocomplete-wrapper": {
+              display: "flex",
+              justifyContent: "flex-end",
+            },
+            ".mantine-Autocomplete-input": {
+              width: mobileExpanded ? "280px" : "32px",
+              backgroundColor: "transparent",
+              borderColor: theme.colors.gray[4],
+              transition: "all 0.5s ease-in-out",
 
-          "&::placeholder": {
-            color: theme.colors.gray[4],
-          },
-        },
-        ".mantine-Autocomplete-icon": {
-          color: theme.colors.gray[3],
-        },
-        ".mantine-Autocomplete-dropdown": {
-          backgroundColor: theme.colors.navy[6],
-        },
-      })}
-      value={searchTerm}
-      onChange={(term) => {
-        setSearchResults([])
-        setSearchTerm(term)
-      }}
-      onItemSubmit={(item: AutocompleteItem) => {
-        navigate(item.link)
-        setSearchTerm("")
-      }}
-    />
+              "&::placeholder": {
+                color: theme.colors.gray[4],
+              },
+            },
+            ".mantine-Autocomplete-icon": {
+              color: theme.colors.gray[3],
+            },
+            ".mantine-Autocomplete-dropdown": {
+              backgroundColor: theme.colors.navy[6],
+            },
+          })}
+          value={searchTerm}
+          onChange={(term) => {
+            setSearchResults([])
+            setSearchTerm(term)
+          }}
+          onClick={() => setMobileExpanded(true)}
+          onDropdownClose={() => setMobileExpanded(false)}
+          onItemSubmit={(item: AutocompleteItem) => {
+            navigate(item.link)
+            setSearchTerm("")
+          }}
+        />
+      </MediaQuery>
+
+      <MediaQuery smallerThan="md" styles={{ display: "none" }}>
+        <Autocomplete
+          aria-label="Documentation search"
+          data={fetcher.state === "submitting" ? [] : searchResultsData}
+          dropdownComponent="div"
+          filter={(_, item) => Boolean(item.value)}
+          icon={<IconSearch />}
+          itemComponent={AutoCompleteSearchItem}
+          limit={20}
+          nothingFound={nothingFoundText}
+          placeholder="Search in Docs"
+          rightSection={autocompleteRightSection}
+          rightSectionWidth={25}
+          size="md"
+          styles={{
+            rightSection: {
+              paddingRight: 5,
+            },
+          }}
+          sx={(theme) => ({
+            width: "560px",
+            ".mantine-Autocomplete-itemsWrapper": {
+              maxHeight: "500px",
+            },
+            ".mantine-Autocomplete-wrapper": {
+              display: "flex",
+              justifyContent: "flex-end",
+            },
+            ".mantine-Autocomplete-input": {
+              width: "350px",
+              backgroundColor: "transparent",
+              borderColor: theme.colors.gray[4],
+
+              "&::placeholder": {
+                color: theme.colors.gray[4],
+              },
+            },
+            ".mantine-Autocomplete-icon": {
+              color: theme.colors.gray[3],
+            },
+            ".mantine-Autocomplete-dropdown": {
+              backgroundColor: theme.colors.navy[6],
+            },
+          })}
+          value={searchTerm}
+          onChange={(term) => {
+            setSearchResults([])
+            setSearchTerm(term)
+          }}
+          onItemSubmit={(item: AutocompleteItem) => {
+            navigate(item.link)
+            setSearchTerm("")
+          }}
+        />
+      </MediaQuery>
+    </>
   )
 }
 

--- a/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
+++ b/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
@@ -3,6 +3,7 @@ import {
   AutocompleteItem,
   AutocompleteProps,
   IconSearch,
+  MantineTheme,
   MediaQuery,
   Sx,
 } from "@pokt-foundation/pocket-blocks"
@@ -16,13 +17,35 @@ interface DocumentationSearchProps {
   docsLinks: LinksGroupProps[]
 }
 
-interface PAutocompleteProps
+interface CustomAutocompleteProps
   extends DocumentationSearchProps,
     Partial<AutocompleteProps> {
   sx?: Sx | (Sx | undefined)[] | undefined
 }
 
-function PAutocomplete({ docsLinks, sx, ...props }: PAutocompleteProps) {
+const commonStyles = (theme: MantineTheme) => ({
+  ".mantine-Autocomplete-itemsWrapper": {
+    maxHeight: "500px",
+  },
+  ".mantine-Autocomplete-wrapper": {
+    display: "flex",
+    justifyContent: "flex-end",
+  },
+  ".mantine-Autocomplete-icon": {
+    color: theme.colors.gray[3],
+  },
+  ".mantine-Autocomplete-dropdown": {
+    backgroundColor: theme.colors.navy[6],
+  },
+})
+
+const rightSectionStyles = {
+  rightSection: {
+    paddingRight: 5,
+  },
+}
+
+function CustomAutocomplete({ docsLinks, sx, ...props }: CustomAutocompleteProps) {
   const navigate = useNavigate()
   const fetcher = useFetcher()
 
@@ -50,11 +73,7 @@ function PAutocomplete({ docsLinks, sx, ...props }: PAutocompleteProps) {
       rightSection={autocompleteRightSection}
       rightSectionWidth={25}
       size="md"
-      styles={{
-        rightSection: {
-          paddingRight: 5,
-        },
-      }}
+      styles={rightSectionStyles}
       sx={sx}
       value={searchTerm}
       onChange={(term) => {
@@ -75,32 +94,19 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
   return (
     <>
       <MediaQuery largerThan="md" styles={{ display: "none" }}>
-        <PAutocomplete
+        <CustomAutocomplete
           docsLinks={docsLinks}
           sx={(theme) => ({
+            ...commonStyles(theme),
             width: "280px",
-            ".mantine-Autocomplete-itemsWrapper": {
-              maxHeight: "500px",
-            },
-            ".mantine-Autocomplete-wrapper": {
-              display: "flex",
-              justifyContent: "flex-end",
-            },
             ".mantine-Autocomplete-input": {
               width: mobileExpanded ? "280px" : "32px",
               backgroundColor: "transparent",
               borderColor: theme.colors.gray[4],
               transition: "all 0.5s ease-in-out",
-
               "&::placeholder": {
                 color: theme.colors.gray[4],
               },
-            },
-            ".mantine-Autocomplete-icon": {
-              color: theme.colors.gray[3],
-            },
-            ".mantine-Autocomplete-dropdown": {
-              backgroundColor: theme.colors.navy[6],
             },
           })}
           onClick={() => setMobileExpanded(true)}
@@ -109,31 +115,18 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
       </MediaQuery>
 
       <MediaQuery smallerThan="md" styles={{ display: "none" }}>
-        <PAutocomplete
+        <CustomAutocomplete
           docsLinks={docsLinks}
           sx={(theme) => ({
+            ...commonStyles(theme),
             width: "560px",
-            ".mantine-Autocomplete-itemsWrapper": {
-              maxHeight: "500px",
-            },
-            ".mantine-Autocomplete-wrapper": {
-              display: "flex",
-              justifyContent: "flex-end",
-            },
             ".mantine-Autocomplete-input": {
               width: "350px",
               backgroundColor: "transparent",
               borderColor: theme.colors.gray[4],
-
               "&::placeholder": {
                 color: theme.colors.gray[4],
               },
-            },
-            ".mantine-Autocomplete-icon": {
-              color: theme.colors.gray[3],
-            },
-            ".mantine-Autocomplete-dropdown": {
-              backgroundColor: theme.colors.navy[6],
             },
           })}
         />

--- a/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
+++ b/app/routes/_landing.($lang).docs/components/DocumentationSearch/DocumentationSearch.tsx
@@ -11,7 +11,10 @@ import { useFetcher, useNavigate } from "@remix-run/react"
 import { useState } from "react"
 import { LinksGroupProps } from "~/components/LinksGroup/LinksGroup"
 import AutoCompleteSearchItem from "~/components/SearchAutoCompleteItem"
-import { useDocumentationSearch } from "~/routes/_landing.($lang).docs/hooks"
+import {
+  UseDocumentationSearchReturnType,
+  useDocumentationSearch,
+} from "~/routes/_landing.($lang).docs/hooks"
 
 interface DocumentationSearchProps {
   docsLinks: LinksGroupProps[]
@@ -21,6 +24,7 @@ interface CustomAutocompleteProps
   extends DocumentationSearchProps,
     Partial<AutocompleteProps> {
   sx?: Sx | (Sx | undefined)[] | undefined
+  searchData: UseDocumentationSearchReturnType
 }
 
 const commonStyles = (theme: MantineTheme) => ({
@@ -45,18 +49,23 @@ const rightSectionStyles = {
   },
 }
 
-function CustomAutocomplete({ docsLinks, sx, ...props }: CustomAutocompleteProps) {
+function CustomAutocomplete({
+  docsLinks,
+  sx,
+  searchData,
+  ...props
+}: CustomAutocompleteProps) {
   const navigate = useNavigate()
   const fetcher = useFetcher()
 
   const {
-    searchResultsData,
-    searchTerm,
-    setSearchTerm,
-    setSearchResults,
     autocompleteRightSection,
     nothingFoundText,
-  } = useDocumentationSearch({ fetcher, docsLinks })
+    searchResultsData,
+    searchTerm,
+    setSearchResults,
+    setSearchTerm,
+  } = searchData
 
   return (
     <Autocomplete
@@ -90,12 +99,16 @@ function CustomAutocomplete({ docsLinks, sx, ...props }: CustomAutocompleteProps
 
 export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => {
   const [mobileExpanded, setMobileExpanded] = useState(false)
+  const fetcher = useFetcher()
+
+  const searchData = useDocumentationSearch({ fetcher, docsLinks })
 
   return (
     <>
-      <MediaQuery largerThan="md" styles={{ display: "none" }}>
+      <MediaQuery largerThan="xs" styles={{ display: "none" }}>
         <CustomAutocomplete
           docsLinks={docsLinks}
+          searchData={searchData}
           sx={(theme) => ({
             ...commonStyles(theme),
             width: "280px",
@@ -104,6 +117,7 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
               backgroundColor: "transparent",
               borderColor: theme.colors.gray[4],
               transition: "all 0.5s ease-in-out",
+              paddingRight: searchData.searchTerm ? "1rem" : 0,
               "&::placeholder": {
                 color: theme.colors.gray[4],
               },
@@ -114,9 +128,10 @@ export const DocumentationSearch = ({ docsLinks }: DocumentationSearchProps) => 
         />
       </MediaQuery>
 
-      <MediaQuery smallerThan="md" styles={{ display: "none" }}>
+      <MediaQuery smallerThan="xs" styles={{ display: "none" }}>
         <CustomAutocomplete
           docsLinks={docsLinks}
+          searchData={searchData}
           sx={(theme) => ({
             ...commonStyles(theme),
             width: "560px",

--- a/app/routes/_landing.($lang).docs/hooks/useDocumentationSearch.tsx
+++ b/app/routes/_landing.($lang).docs/hooks/useDocumentationSearch.tsx
@@ -70,7 +70,6 @@ export const useDocumentationSearch = ({
               doc && doc.translations && doc.translations[0]?.title
                 ? doc?.translations[0]?.title
                 : doc.id,
-            description: doc && doc.translations && doc.translations[0]?.summary,
           }))
       : []
   }, [docsLinks, searchResults])

--- a/app/routes/_landing.($lang).docs/hooks/useDocumentationSearch.tsx
+++ b/app/routes/_landing.($lang).docs/hooks/useDocumentationSearch.tsx
@@ -19,7 +19,7 @@ type UseDocumentationSearchProps = {
   docsLinks: LinksGroupProps[]
 }
 
-type UseDocumentationSearchReturnType = {
+export type UseDocumentationSearchReturnType = {
   searchTerm: string
   setSearchResults: (
     value: ((prevState: documentation[]) => documentation[]) | documentation[],

--- a/app/routes/_landing.($lang).docs/hooks/useDocumentationSearch.tsx
+++ b/app/routes/_landing.($lang).docs/hooks/useDocumentationSearch.tsx
@@ -63,13 +63,14 @@ export const useDocumentationSearch = ({
     return searchResults.length > 0
       ? searchResults
           .filter((doc) => doc?.translations && doc.translations.length > 0)
-          .map((doc, i) => ({
+          .map((doc) => ({
             ...doc,
             link: docsLinks.find(({ id }) => id === doc.id)?.link,
             value:
               doc && doc.translations && doc.translations[0]?.title
                 ? doc?.translations[0]?.title
                 : doc.id,
+            description: doc && doc.translations && doc.translations[0]?.summary,
           }))
       : []
   }, [docsLinks, searchResults])


### PR DESCRIPTION
# Overview

- Added mobile version of docs search bar component. I used media query Mantine component to completely separate concerns with the desktop version
- Added new state "mobileExpanded" which helps control when the mobile version should "expand". It opens when clicked and closes when clicked outside (behaves just like the dropdown).
- Added description to dropdown fields to match expected behavior
- Updated dropdown styles to match designs

# Evidence


https://github.com/pokt-foundation/pocket-portal/assets/26576400/b234d006-d177-4495-9c1c-871f8dfaefff

